### PR TITLE
feat(QueryBuilder): add CountBuilder support for counting records

### DIFF
--- a/src/ORM/Drivers/PDODriver.php
+++ b/src/ORM/Drivers/PDODriver.php
@@ -103,6 +103,16 @@ class PDODriver implements DatabaseDriver
      */
     public function quoteIdentifier(string $name): string
     {
+        // If it looks like a SQL function call or *
+        if (
+            $name === '*' ||
+            str_contains($name, '(') || // function()
+            str_contains($name, '.') || // table.column
+            preg_match('/^\s*[A-Z]+\(/', $name) // e.g. COUNT(
+        ) {
+            return $name;
+        }
+
         return "`$name`";
     }
 }

--- a/src/ORM/Persistence/DeleteExecutor.php
+++ b/src/ORM/Persistence/DeleteExecutor.php
@@ -13,8 +13,8 @@ use RuntimeException;
 final readonly class DeleteExecutor
 {
     public function __construct(
-        private DatabaseDriver   $databaseDriver,
-        private MetadataParser   $metadataParser,
+        private DatabaseDriver $databaseDriver,
+        private MetadataParser $metadataParser,
         private ?LoggerInterface $logger = null,
     ) {}
 
@@ -27,9 +27,8 @@ final readonly class DeleteExecutor
     {
         $metadata = $this->metadataParser->parse($entity::class);
         $data = $this->metadataParser->extract($entity);
-
-        $primaryKey = $metadata->getPrimaryKey();
-        $id = $data[$primaryKey] ?? null;
+        $primaryKeyName = $metadata->getPrimaryKey();
+        $id = $data[$primaryKeyName] ?? null;
 
         if ($id === null) {
             throw new RuntimeException("Cannot delete entity without identifier.");
@@ -37,7 +36,7 @@ final readonly class DeleteExecutor
 
         new QueryBuilder($this->databaseDriver, $this->logger)
             ->delete()
-            ->fromMetadata($metadata, $id)
+            ->fromMetadata($metadata, [$primaryKeyName => $id])
             ->execute();
     }
 }

--- a/src/ORM/Query/Builder/CountBuilder.php
+++ b/src/ORM/Query/Builder/CountBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ORM\Query\Builder;
+
+use ORM\Metadata\MetadataEntity;
+use ORM\Query\QueryBuilder;
+
+final class CountBuilder
+{
+    public function apply(
+        QueryBuilder $queryBuilder,
+        MetadataEntity $metadata,
+        array $criteria,
+        array $options = []
+    ): void {
+        $alias = $metadata->getAlias();
+        $column = $options["distinct"] ?? false
+            ? "DISTINCT $alias.{$metadata->getPrimaryKey()}"
+            : "*";
+
+        $queryBuilder
+            ->select(["COUNT($column)" => "count"])
+            ->table($metadata->getTable(), $metadata->getAlias());
+
+        [$where, $parameters] = new WhereBuilder()->build($metadata, $queryBuilder->getContext(), $criteria);
+        $queryBuilder->where($where, $parameters);
+    }
+}

--- a/src/ORM/Query/Builder/DeleteBuilder.php
+++ b/src/ORM/Query/Builder/DeleteBuilder.php
@@ -12,13 +12,9 @@ final readonly class DeleteBuilder
         private WhereBuilder $whereBuilder = new WhereBuilder(),
     ) {}
 
-    public function apply(QueryBuilder $queryBuilder, MetadataEntity $metadata, int|string|array|null $id): void
+    public function apply(QueryBuilder $queryBuilder, MetadataEntity $metadata, array $criteria): void
     {
-        if ($id === null) {
-            throw new InvalidArgumentException("Missing identifier for delete");
-        }
-
-        [$where, $params] = $this->whereBuilder->build($metadata, $queryBuilder->getContext(), $id);
+        [$where, $params] = $this->whereBuilder->build($metadata, $queryBuilder->getContext(), $criteria);
         $queryBuilder->where($where, $params);
     }
 }

--- a/src/ORM/Query/Builder/SelectBuilder.php
+++ b/src/ORM/Query/Builder/SelectBuilder.php
@@ -16,9 +16,8 @@ final readonly class SelectBuilder
     public function apply(
         QueryBuilder $queryBuilder,
         MetadataEntity $metadata,
-        int|string|array|null $conditions = null,
+        array $criteria = [],
         ?callable $resolveMetadata = null,
-//        array $eagerRelations = [],
         array $options = [],
     ): void {
         $select = [];
@@ -44,11 +43,8 @@ final readonly class SelectBuilder
             $this->joinBuilder->apply($queryBuilder, $metadata, $eagerRelations, $resolveMetadata);
         }
 
-        [$where, $parameters] = $this->whereBuilder->build($metadata, $queryBuilder->getContext(), $conditions);
+        [$where, $parameters] = $this->whereBuilder->build($metadata, $queryBuilder->getContext(), $criteria);
         $queryBuilder->where($where, $parameters);
-
-
-        var_dump($options);
         $this->applyOptions($queryBuilder, $options);
     }
 

--- a/src/ORM/Query/Builder/WhereBuilder.php
+++ b/src/ORM/Query/Builder/WhereBuilder.php
@@ -2,42 +2,30 @@
 
 namespace ORM\Query\Builder;
 
-use InvalidArgumentException;
 use ORM\Metadata\MetadataEntity;
 use ORM\Query\QueryContext;
 
 final class WhereBuilder
 {
     /**
-     * Builds the WHERE clause structure and SQL parameters.
+     * Builds the WHERE clause and SQL parameters based on normalized criteria.
      *
      * @param MetadataEntity $metadata
      * @param QueryContext $context
-     * @param int|string|array|null $conditions
+     * @param array $criteria Always normalized to associative array (key => value)
      *
-     * @return array{where: array<string,string>, parameters: array<string,mixed>}
+     * @return array{0: array<string, string>, 1: array<string, mixed>}
      */
-    public function build(MetadataEntity $metadata, QueryContext $context, int|string|array|null $conditions = null): array
+    public function build(MetadataEntity $metadata, QueryContext $context, array $criteria): array
     {
         $where = [];
         $parameters = [];
-        $primaryKey = $metadata->getPrimaryKey();
 
         $prefix = $context->useAlias()
             ? $metadata->getAlias() . '.'
             : '';
 
-        if ($conditions === null) {
-            return [[], []];
-        }
-
-        if (!is_array($conditions)) {
-            $where["{$prefix}{$primaryKey}"] = ":{$primaryKey}";
-            $parameters[$primaryKey] = $conditions;
-            return [$where, $parameters];
-        }
-
-        foreach ($conditions as $key => $value) {
+        foreach ($criteria as $key => $value) {
             $where["{$prefix}{$key}"] = ":{$key}";
             $parameters[$key] = $value;
         }

--- a/src/ORM/Query/QueryContext.php
+++ b/src/ORM/Query/QueryContext.php
@@ -13,7 +13,7 @@ namespace ORM\Query;
  * - JOIN clauses
  * - named SQL parameters
  *
- * @see \ORM\Query\QueryBuilder
+ * @see QueryBuilder
  */
 final class QueryContext
 {


### PR DESCRIPTION
- Introduced `count()` method to simplify count queries
- Added `CountBuilder` to handle COUNT logic via metadata
- Normalized criteria using entity primary key
- Integrated count flow into `fromMetadata()` for consistency
- Ensures `getSQL()` works without explicit `count` case