### PR TITLE
fix(EntityBase): improve persisted detection and enforce jsonSerializ…

### DIFF
--- a/src/ORM/Entity/EntityBase.php
+++ b/src/ORM/Entity/EntityBase.php
@@ -3,25 +3,20 @@
 namespace ORM\Entity;
 
 use JsonSerializable;
+use LogicException;
 
 abstract class EntityBase implements JsonSerializable
 {
     private ?array $__originalData = null;
 
-    protected bool $__persisted = false;
-
     public function __markPersisted(array $data): void
     {
-        $this->__persisted = true;
-        if (!empty($data))
-        {
-            $this->__originalData = $data;
-        }
+        $this->__originalData = $data;
     }
 
     public function __isPersisted(): bool
     {
-        return $this->__persisted;
+        return !empty($this->__originalData);
     }
 
     public function __takeSnapshot(array $data): void
@@ -34,26 +29,11 @@ abstract class EntityBase implements JsonSerializable
         return $this->__originalData !== $data;
     }
 
-//    public function __getChanges(array $data): array
-//    {
-//        if ($this->__originalData === null) return [];
-//
-//        return array_diff_assoc($data, $this->__originalData);
-//    }
-
-    /**
-     * Override this in your Entity to expose the actual ID.
-     */
-    public function getId(): int|string|null
-    {
-        return null;
-    }
-
     /**
      * Basic default serialization. Should be overridden in entities.
      */
     public function jsonSerialize(): mixed
     {
-        return get_object_vars($this);
+        throw new LogicException("Entity '". static::class ."' must implement its own jsonSerialize() method.");
     }
 }


### PR DESCRIPTION
…e override

- Changed __isPersisted() to rely on internal snapshot data for accuracy
- Added LogicException to jsonSerialize() to enforce explicit implementation in child entities
- Prevents accidental serialization of closures or internal state