### PR TITLE
feat(cache): add EntityCache and integrate into EntityManager & Execu…

### DIFF
--- a/src/ORM/Cache/EntityCache.php
+++ b/src/ORM/Cache/EntityCache.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ORM\Cache;
+
+use ORM\Entity\EntityBase;
+
+interface EntityCache
+{
+    public function get(string $class, int|string $id): ?EntityBase;
+    public function set(string $class, int|string $id, EntityBase $entity): void;
+    public function clear(string $class, int|string $id): void;
+    public function clearAll(): void;
+}

--- a/src/ORM/Cache/InMemoryEntityCache.php
+++ b/src/ORM/Cache/InMemoryEntityCache.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ORM\Cache;
+
+use ORM\Entity\EntityBase;
+
+final class InMemoryEntityCache implements EntityCache
+{
+    private array $identityMap = [];
+
+    public function get(string $class, int|string $id): ?EntityBase
+    {
+        return $this->identityMap[$class][$id] ?? null;
+    }
+
+    public function set(string $class, int|string $id, EntityBase $entity): void
+    {
+        $this->identityMap[$class][$id] = $entity;
+    }
+
+    public function clear(string $class, int|string $id): void
+    {
+        unset($this->identityMap[$class][$id]);
+    }
+
+    public function clearAll(): void
+    {
+        $this->identityMap = [];
+    }
+}

--- a/src/ORM/Persistence/DeleteExecutor.php
+++ b/src/ORM/Persistence/DeleteExecutor.php
@@ -2,6 +2,7 @@
 
 namespace ORM\Persistence;
 
+use ORM\Cache\EntityCache;
 use ORM\Drivers\DatabaseDriver;
 use ORM\Entity\EntityBase;
 use ORM\Metadata\MetadataParser;
@@ -15,6 +16,7 @@ final readonly class DeleteExecutor
     public function __construct(
         private DatabaseDriver $databaseDriver,
         private MetadataParser $metadataParser,
+        private EntityCache $entityCache,
         private ?LoggerInterface $logger = null,
     ) {}
 
@@ -38,5 +40,9 @@ final readonly class DeleteExecutor
             ->delete()
             ->fromMetadata($metadata, null, [], [$primaryKeyName => $id])
             ->execute();
+
+        if (is_scalar($id)) {
+            $this->entityCache->clear($entity::class, $id);
+        }
     }
 }

--- a/src/ORM/Persistence/InsertExecutor.php
+++ b/src/ORM/Persistence/InsertExecutor.php
@@ -2,6 +2,7 @@
 
 namespace ORM\Persistence;
 
+use ORM\Cache\EntityCache;
 use ORM\Drivers\DatabaseDriver;
 use ORM\Entity\EntityBase;
 use ORM\Metadata\MetadataParser;
@@ -12,8 +13,9 @@ use ReflectionException;
 final readonly class InsertExecutor
 {
     public function __construct(
-        private DatabaseDriver   $databaseDriver,
-        private MetadataParser   $metadataParser,
+        private DatabaseDriver $databaseDriver,
+        private MetadataParser $metadataParser,
+        private EntityCache $entityCache,
         private ?LoggerInterface $logger = null,
     ) {}
 
@@ -38,5 +40,13 @@ final readonly class InsertExecutor
         }
 
         $entity->__markPersisted($this->metadataParser->extract($entity));
+
+        $id = $this->metadataParser
+            ->getReflectionCache()
+            ->getValue($entity, $metadata->getPrimaryKey());
+
+        if (is_scalar($id)) {
+            $this->entityCache->set($entity::class, $id, $entity);
+        }
     }
 }

--- a/src/ORM/UnitOfWork.php
+++ b/src/ORM/UnitOfWork.php
@@ -2,6 +2,7 @@
 
 namespace ORM;
 
+use ORM\Cache\EntityCache;
 use ORM\Drivers\DatabaseDriver;
 use ORM\Entity\EntityBase;
 use ORM\Entity\Type\CascadeType;
@@ -27,11 +28,12 @@ class UnitOfWork
     public function __construct(
         readonly DatabaseDriver $databaseDriver,
         private readonly MetadataParser $metadataParser,
+        readonly EntityCache $entityCache,
         readonly ?LoggerInterface $logger = null,
     ) {
-        $this->insertExecutor = new InsertExecutor($databaseDriver, $metadataParser, $logger);
-        $this->updateExecutor = new UpdateExecutor($databaseDriver, $metadataParser, $logger);
-        $this->deleteExecutor = new DeleteExecutor($databaseDriver, $metadataParser, $logger);
+        $this->insertExecutor = new InsertExecutor($databaseDriver, $metadataParser, $entityCache,$logger);
+        $this->updateExecutor = new UpdateExecutor($databaseDriver, $metadataParser, $entityCache, $logger);
+        $this->deleteExecutor = new DeleteExecutor($databaseDriver, $metadataParser, $entityCache, $logger);
         $this->cascadeHandler = new CascadeHandler($metadataParser, $this);
         $this->scheduledForInsert = new SplObjectStorage();
         $this->scheduledForUpdate = new SplObjectStorage();


### PR DESCRIPTION
…tors

- Introduced EntityCache interface and InMemoryEntityCache implementation
- Injected EntityCache into EntityManager and UnitOfWork
- Hydrated entities are now cached based on class and primary key
- Cache lookup added to findBy(), findAll(), streamBy(), streamAll()
- InsertExecutor now caches inserted entities
- UpdateExecutor now updates cache after update
- DeleteExecutor now clears cache entry on deletion